### PR TITLE
FIX: browser "should" variabal

### DIFF
--- a/should-sinon.js
+++ b/should-sinon.js
@@ -4,7 +4,7 @@
   } else if (typeof exports === 'object') {
     module.exports = factory(require('should'));
   } else {
-    factory(Should);
+    factory(should);
   }
 }(function (should) {
   var Assertion = should.Assertion;


### PR DESCRIPTION
Is it a typo? can't find Should in browser, it should be 'should', I have tried it.